### PR TITLE
Fix yarn dev command in readme

### DIFF
--- a/02/README.md
+++ b/02/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/eastuto/my-blog-01.git
 cd my-blog-01/02
 yarn
 yarn dev:reason
-yarn dev 
+yarn dev:next
 ```
 
 ### View the pages


### PR DESCRIPTION
I replaced 'yarn dev' with 'yarn dev:next' in the readme file.  The command 'yarn dev' didn't work for me.  I noticed 'dev:next' in package.json.  Thanks for the videos.  They are great.